### PR TITLE
feat(checkout): final-of-class checkout flow + live QR phase + frozen presence

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -109,6 +109,17 @@ def init_db() -> None:
     except sqlite3.OperationalError:
         pass
 
+    # --- freeze snapshot columns on session (idempotent) ---
+    try:
+        cur.execute("ALTER TABLE session ADD COLUMN present_frozen INTEGER")
+    except sqlite3.OperationalError:
+        pass
+    try:
+        cur.execute("ALTER TABLE session ADD COLUMN present_frozen_at TEXT")
+    except sqlite3.OperationalError:
+        pass
+    conn.commit()
+
     def _ensure_attendance_allows_plecat(conn):
         cur = conn.cursor()
         row = cur.execute(

--- a/app/db.py
+++ b/app/db.py
@@ -102,6 +102,53 @@ def init_db() -> None:
         """
     )
 
+
+
+    try:
+        cur.execute("ALTER TABLE attendance ADD COLUMN check_out_at TEXT")
+    except sqlite3.OperationalError:
+        pass
+
+    def _ensure_attendance_allows_plecat(conn):
+        cur = conn.cursor()
+        row = cur.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='attendance'"
+        ).fetchone()
+        if not row:
+            return  # tabela va fi creată oricum mai sus
+        create_sql = row[0] or ""
+        if "plecat" in create_sql:
+            return  # deja e ok
+
+        # Migrare: recreăm tabela cu CHECK extins
+        cur.execute("PRAGMA foreign_keys=OFF")
+        conn.commit()
+
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS attendance_new (
+                id INTEGER PRIMARY KEY,
+                session_id INTEGER NOT NULL,
+                class_id TEXT NOT NULL,
+                code4_hash TEXT,
+                status TEXT NOT NULL CHECK (status IN ('neconfirmat','prezent','întârziat','plecat')),
+                check_in_at TEXT,
+                check_out_at TEXT,
+                UNIQUE(session_id, code4_hash)
+            )
+        """)
+        # Copiem toate datele existente (coloanele trebuie să existe deja; ai adăugat check_out_at mai sus)
+        cur.execute("""
+            INSERT INTO attendance_new (id, session_id, class_id, code4_hash, status, check_in_at, check_out_at)
+            SELECT id, session_id, class_id, code4_hash, status, check_in_at, check_out_at
+            FROM attendance
+        """)
+        cur.execute("DROP TABLE attendance")
+        cur.execute("ALTER TABLE attendance_new RENAME TO attendance")
+        cur.execute("PRAGMA foreign_keys=ON")
+        conn.commit()
+
+    _ensure_attendance_allows_plecat(conn)
+
     conn.commit()
     conn.close()
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -111,7 +111,7 @@ def monitor():
     s = get_qr_serializer(current_app)
     qr_token = s.dumps({"session_id": session_id, "phase": phase})
     qr_title = "Cod de început de oră" if phase == "start" else "Cod de final de oră"
-    print(codes_ui)
+
     return render_template(
         "monitor.html",
         class_id=class_id,
@@ -386,6 +386,8 @@ def api_monitor_status():
     else:
         present_count = present_now
 
+    left_count = sum(1 for st in status_map.values() if st == "plecat")
+
     data_curenta = now.strftime("%d %b %Y")  # ex: 23 Sep 2025
 
     return jsonify({
@@ -400,6 +402,7 @@ def api_monitor_status():
         "data_curenta": data_curenta,
         "mode": mode,
         "sleep_until": sleep_until,
+        "left_count": left_count
     })
 
 

--- a/static/css/monitor.css
+++ b/static/css/monitor.css
@@ -60,6 +60,7 @@
     .present{background: rgba(52,211,153,.15); color:#86efac; border:1px solid rgba(52,211,153,.35)}
     .missing{background: rgba(148,163,184,.12); color:#ff0000; border:1px solid rgba(148,163,184,.25)}
     .late{background: rgba(148,163,184,.12); color:#ffff00; border:1px solid rgba(148,163,184,.25)}
+    .gone{background: rgba(148,163,184,.12); color:#22d3ee; border:1px solid rgba(148,163,184,.25)}
     .badge .dot{width:.6rem; height:.6rem; border-radius:50%; background: currentColor; opacity:.9}
 
     /* Right side: QR & Counter */

--- a/static/css/monitor.css
+++ b/static/css/monitor.css
@@ -21,7 +21,7 @@
     /* Header */
     header{
       display:grid; grid-template-columns: 1fr auto; align-items:center;
-      gap:2rem; padding:1.2rem 2rem; background: rgba(17,24,39,.6); backdrop-filter: blur(6px);
+      gap:0.5rem; padding:1.2rem 2rem; background: rgba(17,24,39,.6); backdrop-filter: blur(6px);
       border-bottom: 1px solid rgba(148,163,184,.12);
     }
     .clock{font-size: clamp(2rem, 6vw, 5rem); font-weight:800; letter-spacing: .02em;}

--- a/templates/elev.html
+++ b/templates/elev.html
@@ -26,6 +26,8 @@
         {% endif %}
         <form class="code" action="{{ url_for('main.elev') }}?session_id={{ session_id }}" method="post" autocomplete="one-time-code">
           <div class="code-boxes" aria-label="Introdu codul din 4 cifre">
+            <input type="hidden" name="token" value="{{ request.args.get('token','') }}">
+            <input type="hidden" name="session_id" value="{{ session_id }}">
             <input name="d1" type="text" inputmode="numeric" maxlength="1" aria-label="Cifra 1" />
             <input name="d2" type="text" inputmode="numeric" maxlength="1" aria-label="Cifra 2" />
             <input name="d3" type="text" inputmode="numeric" maxlength="1" aria-label="Cifra 3" />

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -2,80 +2,132 @@
 <!DOCTYPE html>
 <html lang="ro">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{{ title }}</title>
-  <meta http-equiv="refresh" content="10"> <!-- auto-refresh simplu -->
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v={{ config['ASSET_VER'] }}">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/monitor.css') }}?v={{ config['ASSET_VER'] }}">
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>{{ title }}</title>
+    <meta http-equiv="refresh" content="10"> <!-- auto-refresh simplu -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v={{ config['ASSET_VER'] }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/monitor.css') }}?v={{ config['ASSET_VER'] }}">
 
 </head>
 <body>
-  <div class="wrap">
+<div class="wrap">
     <header>
-      <div class="clock" aria-live="polite">{{ ora_curenta }}</div>
-      <div class="class-pill">Acum la religie: <strong>Clasa {{ class_id }}</strong></div>
+        <div class="clock" aria-live="polite">{{ ora_curenta }}</div>
+        <div class="class-pill">Acum la religie: <strong>Clasa {{ class_id }}</strong></div>
     </header>
 
     <main class="main">
-      <section class="card" aria-labelledby="list-coduri">
-        <h2 id="list-coduri">Elevi care nu participă la ora de religie</h2>
-        <p class="sub">Fereastră check‑in: {{ window_label }}. Bife verzi = prezenți.</p>
-        <div class="codes" role="list">
-          {% for c in codes %}
-          <div class="code" role="listitem">
-            <b>••{{ loop.index0 ~ loop.index0 }}</b> <!-- mascăm; poți înlocui cu altă logică -->
-            {% if c.status == 'prezent' %}
-              <span class="badge present" title="prezent"><span class="dot"></span> prezent</span>
-            {% elif c.status == 'întârziat' %}
-              <span class="badge late" title="întârziat"><span class="dot"></span> întârziat</span>
-            {% else %}
-              <span class="badge missing" title="neconfirmat">neconfirmat</span>
-            {% endif %}
-          </div>
-          {% endfor %}
-        </div>
-        <div class="counter" aria-live="polite">
-          Prezenți: <span class="pill">{{ present_count }} / {{ total }}</span>
-        </div>
-      </section>
+        <section class="card" aria-labelledby="list-coduri">
+            <h2 id="list-coduri">Elevi care nu participă la ora de religie</h2>
+            <p class="sub">Fereastră check‑in: {{ window_label }}. Bife verzi = prezenți.</p>
+            <div class="codes" role="list">
+                {% for c in codes %}
+                <div class="code" role="listitem">
+                    <b>{{ c.code4 }}</b> <!-- mascăm; poți înlocui cu altă logică -->
+                    {% if c.status == 'prezent' %}
+                    <span class="badge present" title="prezent"><span class="dot"></span> prezent</span>
+                    {% elif c.status == 'întârziat' %}
+                    <span class="badge late" title="întârziat"><span class="dot"></span> întârziat</span>
+                    {% elif c.status == 'plecat' %}
+                    <span class="badge gone" title="plecat"><span class="dot"></span> plecat</span>
+                    {% else %}
+                    <span class="badge missing" title="neconfirmat">neconfirmat</span>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+            <div class="counter" aria-live="polite">
+                Prezenți: <span class="pill">{{ present_count }} / {{ total }}</span>
+            </div>
+            <div class="counter" aria-live="polite">
+                Plecați: <span class="pill">{{ left_count }} / {{ total }}</span>
+            </div>
 
-      <aside class="card qr-panel" aria-labelledby="qr-title">
-        <h2 id="qr-title">Cod de început de oră</h2>
-        <div class="qr-box" aria-label="cod QR — scanează pentru a confirma prezența">
-          <img src="{{ url_for('main.qr_png') }}?token={{ qr_token }}&v={{ ora_curenta }}" alt="QR check-in">
+        </section>
 
-        </div>
-        <div class="qr-caption">Scanează pentru a-ți confirma prezența</div>
-      </aside>
+        <aside class="card qr-panel" aria-labelledby="qr-title">
+            <h2 id="qr-title">Cod de început de oră</h2>
+            <div class="qr-box" aria-label="cod QR — scanează pentru a confirma prezența">
+                <img src="" alt="QR">
+            </div>
+            <div class="qr-caption">Scanează pentru a-ți confirma prezența</div>
+            <div id="qr-debug" class="qr-caption" style="user-select:all; max-width:500px"></div>
+        </aside>
+
     </main>
 
     <footer>
-      <span>Template demo (static). În implementare, valorile vin din DB.</span>
-      <span class="fs-hint">Sfat: apasă <kbd>F11</kbd> pentru full-screen.</span>
+        <span>Template demo (static). În implementare, valorile vin din DB.</span>
+        <span class="fs-hint">Sfat: apasă <kbd>F11</kbd> pentru full-screen.</span>
     </footer>
-  </div>
+</div>
 
 <script>
-(function(){
-  const sessionId = {{ session_id|int }};
-  const clockEl = document.querySelector('.clock');
-  const subEl = document.querySelector('.sub');
-  const counterEl = document.querySelector('.counter .pill');
+    (function(){
+      const sessionId = {{ session_id|int }};
+      const clockEl = document.querySelector('.clock');
+      const subEl = document.querySelector('.sub');
+      const counterEl = document.querySelector('.counter .pill');
 
-  async function tick(){
-    try{
-      const r = await fetch(`/api/monitor_status?session_id=${sessionId}`, {cache:'no-store'});
-      if(!r.ok) return;
-      const data = await r.json();
-      if(clockEl) clockEl.textContent = data.ora_curenta || '--:--';
-      if(subEl) subEl.textContent = `Fereastră check‑in: ${data.window_label}. Bife verzi = prezenți.`;
-      if(counterEl) counterEl.textContent = `${data.present_count} / ${data.total}`;
-    }catch(e){ /* ignorăm erorile intermitente */ }
-    setTimeout(tick, 3000);
-  }
-  tick();
-})();
+      async function tick(){
+        try{
+          const r = await fetch(`/api/monitor_status?session_id=${sessionId}`, {cache:'no-store'});
+          if(!r.ok) return;
+          const data = await r.json();
+          if(clockEl) clockEl.textContent = data.ora_curenta || '--:--';
+          if(subEl) subEl.textContent = `Fereastră check‑in: ${data.window_label}. Bife verzi = prezenți.`;
+          if(counterEl) counterEl.textContent = `${data.present_count} / ${data.total}`;
+        }catch(e){ /* ignorăm erorile intermitente */ }
+        setTimeout(tick, 3000);
+      }
+      tick();
+    })();
 </script>
+
+<script>
+    (function(){
+      // ia param din URL, nu din Jinja
+      const sessionId = Number(new URLSearchParams(location.search).get('session_id'));
+      if (!sessionId) {
+        console.warn('Lipsește ?session_id= din URL-ul /monitor');
+        return; // evităm fetch-uri 400
+      }
+
+      const clockEl   = document.querySelector('.clock');
+      const subEl     = document.querySelector('.sub');
+      const counterEl = document.querySelector('.counter .pill');
+      const qrImg     = document.querySelector('.qr-box img');
+      const qrTitleEl = document.getElementById('qr-title');
+      const qrDebugEl = document.getElementById('qr-debug');
+
+      let lastToken = null;
+
+      async function tick(){
+        try{
+          const r = await fetch(`/api/monitor_status?session_id=${sessionId}`, {cache:'no-store'});
+          if(!r.ok) return;
+          const data = await r.json();
+
+          if(clockEl) clockEl.textContent = data.ora_curenta || '--:--';
+          if(subEl)   subEl.textContent   = `Fereastră: ${data.window_label || ''}. Bife verzi = prezenți.`;
+          if(counterEl) counterEl.textContent = `${data.present_count} / ${data.total}`;
+
+          if(qrTitleEl) qrTitleEl.textContent = (data.phase === 'end') ? 'Cod de final de oră' : 'Cod de început de oră';
+
+          if(data.qr_token && data.qr_token !== lastToken){
+            lastToken = data.qr_token;
+            const v = encodeURIComponent(data.ora_curenta || Date.now());
+            if(qrImg)   qrImg.src = `/qr.png?token=${data.qr_token}&v=${v}`;
+            if(qrDebugEl) qrDebugEl.textContent = `${location.origin}/elev?token=${data.qr_token}`;
+          }
+        }catch(e){ /* ignorăm erorile intermitente */ }
+        setTimeout(tick, 3000);
+      }
+      tick();
+    })();
+</script>
+
+
 </body>
 </html>

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -14,13 +14,17 @@
 <div class="wrap">
     <header>
         <div class="clock" aria-live="polite">{{ ora_curenta }}</div>
+
+
+
         <div class="class-pill">Acum la religie: <strong>Clasa {{ class_id }}</strong></div>
+        <div class="date" style="opacity:.75;font-size:1.2rem;margin-top:.1rem">—</div>
     </header>
 
     <main class="main">
         <section class="card" aria-labelledby="list-coduri">
             <h2 id="list-coduri">Elevi care nu participă la ora de religie</h2>
-<!--            <p class="sub">Fereastră check‑in: {{ window_label }}. Bife verzi = prezenți.</p>-->
+            <!--            <p class="sub">Fereastră check‑in: {{ window_label }}. Bife verzi = prezenți.</p>-->
             <div class="codes" role="list">
                 {% for c in codes %}
                 <div class="code" role="listitem">
@@ -49,16 +53,16 @@
         <aside class="card qr-panel" aria-labelledby="qr-title">
             <h2 id="qr-title">Cod de început de oră</h2>
             <div class="qr-box" aria-label="cod QR — scanează pentru a confirma prezența">
-                <img src="" alt="QR">
+                <img id="qr-img" src="" alt="QR">
             </div>
-            <div class="qr-caption">Scanează pentru a-ți confirma prezența</div>
+            <div class="qr-caption" id="qr-scan-text"></div>
             <div id="qr-debug" class="qr-caption" style="user-select:all; max-width:500px"></div>
         </aside>
 
     </main>
 
     <footer>
-        <span>Template demo (static). În implementare, valorile vin din DB.</span>
+        <span>Copyright (c) 2025 Colegiul Național "Barbu Știrbei" Călărași</span>
         <span class="fs-hint">Sfat: apasă <kbd>F11</kbd> pentru full-screen.</span>
     </footer>
 </div>
@@ -69,6 +73,7 @@
       const clockEl = document.querySelector('.clock');
       const subEl = document.querySelector('.sub');
       const counterEl = document.querySelector('.counter .pill');
+      const dateEl = document.querySelector('.date');
 
       async function tick(){
         try{
@@ -78,6 +83,7 @@
           if(clockEl) clockEl.textContent = data.ora_curenta || '--:--';
           if(subEl) subEl.textContent = `Fereastră check‑in: ${data.window_label}. Bife verzi = prezenți.`;
           if(counterEl) counterEl.textContent = `${data.present_count} / ${data.total}`;
+          if (dateEl) dateEl.textContent = data.data_curenta || '';
         }catch(e){ /* ignorăm erorile intermitente */ }
         setTimeout(tick, 3000);
       }
@@ -86,46 +92,68 @@
 </script>
 
 <script>
-    (function(){
-      // ia param din URL, nu din Jinja
-      const sessionId = Number(new URLSearchParams(location.search).get('session_id'));
-      if (!sessionId) {
-        console.warn('Lipsește ?session_id= din URL-ul /monitor');
-        return; // evităm fetch-uri 400
+(function(){
+  const params    = new URLSearchParams(location.search);
+  const sessionId = Number(params.get('session_id'));
+  if (!sessionId) { console.warn('Lipsește ?session_id='); return; }
+
+  const clockEl   = document.querySelector('.clock');
+  const dateEl    = document.querySelector('.date');
+  const counterEl = document.querySelector('.counter .pill');
+  const qrImg     = document.getElementById('qr-img');
+  const qrTitleEl = document.getElementById('qr-title');
+  const qrDebugEl = document.getElementById('qr-debug');
+  const qrScanTextEl = document.getElementById('qr-scan-text');
+
+  let lastToken = null;
+
+  async function tick(){
+    try{
+      const r = await fetch(`/api/monitor_status?session_id=${sessionId}`, {cache:'no-store'});
+      if(!r.ok){ console.log('API status', r.status); setTimeout(tick, 3000); return; }
+      const data = await r.json();
+      console.log('API:', {mode: data.mode, hasToken: !!data.qr_token});
+
+      if (clockEl)   clockEl.textContent = data.ora_curenta || '--:--';
+      if (dateEl)    dateEl.textContent  = data.data_curenta || '';
+      if (counterEl) counterEl.textContent = `${data.present_count} / ${data.total}`;
+
+      if (qrTitleEl){
+        qrTitleEl.textContent =
+          data.mode === 'end'    ? 'Cod de final de oră' :
+          data.mode === 'active' ? 'Cod de început de oră' :
+          'Ora este în desfășurare';
       }
 
-      const clockEl   = document.querySelector('.clock');
-      const subEl     = document.querySelector('.sub');
-      const counterEl = document.querySelector('.counter .pill');
-      const qrImg     = document.querySelector('.qr-box img');
-      const qrTitleEl = document.getElementById('qr-title');
-      const qrDebugEl = document.getElementById('qr-debug');
-
-      let lastToken = null;
-
-      async function tick(){
-        try{
-          const r = await fetch(`/api/monitor_status?session_id=${sessionId}`, {cache:'no-store'});
-          if(!r.ok) return;
-          const data = await r.json();
-
-          if(clockEl) clockEl.textContent = data.ora_curenta || '--:--';
-          if(subEl)   subEl.textContent   = `Fereastră: ${data.window_label || ''}. Bife verzi = prezenți.`;
-          if(counterEl) counterEl.textContent = `${data.present_count} / ${data.total}`;
-
-          if(qrTitleEl) qrTitleEl.textContent = (data.phase === 'end') ? 'Cod de final de oră' : 'Cod de început de oră';
-
-          if(data.qr_token && data.qr_token !== lastToken){
-            lastToken = data.qr_token;
-            const v = encodeURIComponent(data.ora_curenta || Date.now());
-            if(qrImg)   qrImg.src = `/qr.png?token=${data.qr_token}&v=${v}`;
-            if(qrDebugEl) qrDebugEl.textContent = `${location.origin}/elev?token=${data.qr_token}`;
-          }
-        }catch(e){ /* ignorăm erorile intermitente */ }
-        setTimeout(tick, 3000);
+       if (qrScanTextEl){
+        qrScanTextEl.textContent =
+          data.mode === 'end'    ? 'Scanează pentru a-ți confirma plecarea' :
+          data.mode === 'active' ? 'Scanează pentru a-ți confirma prezența' :
+          '-';
       }
-      tick();
-    })();
+
+      // setează/ascunde QR
+      if (data.qr_token){
+        const v = encodeURIComponent(data.ora_curenta || Date.now());
+        const src = `/qr.png?token=${data.qr_token}&v=${v}`;
+        if (qrImg){
+          qrImg.src = src;
+          qrImg.style.visibility = 'visible';
+        }
+        if (qrDebugEl) qrDebugEl.textContent = `${location.origin}/elev?token=${data.qr_token}`;
+        lastToken = data.qr_token;
+        console.log('SET QR IMG:', src);
+      } else {
+        if (qrImg) qrImg.style.visibility = 'hidden';
+        if (qrDebugEl) qrDebugEl.textContent = '';
+      }
+    } catch(e){
+      console.error('tick error', e);
+    }
+    setTimeout(tick, 3000);
+  }
+  tick();
+})();
 </script>
 
 

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -20,7 +20,7 @@
     <main class="main">
         <section class="card" aria-labelledby="list-coduri">
             <h2 id="list-coduri">Elevi care nu participă la ora de religie</h2>
-            <p class="sub">Fereastră check‑in: {{ window_label }}. Bife verzi = prezenți.</p>
+<!--            <p class="sub">Fereastră check‑in: {{ window_label }}. Bife verzi = prezenți.</p>-->
             <div class="codes" role="list">
                 {% for c in codes %}
                 <div class="code" role="listitem">

--- a/templates/monitor.html
+++ b/templates/monitor.html
@@ -16,7 +16,6 @@
         <div class="clock" aria-live="polite">{{ ora_curenta }}</div>
 
 
-
         <div class="class-pill">Acum la religie: <strong>Clasa {{ class_id }}</strong></div>
         <div class="date" style="opacity:.75;font-size:1.2rem;margin-top:.1rem">—</div>
     </header>
@@ -42,10 +41,10 @@
                 {% endfor %}
             </div>
             <div class="counter" aria-live="polite">
-                Prezenți: <span class="pill">{{ present_count }} / {{ total }}</span>
+                Prezenți: <span class="pill" id="present-pill">0 / 0</span>
             </div>
             <div class="counter" aria-live="polite">
-                Plecați: <span class="pill">{{ left_count }} / {{ total }}</span>
+                Plecați: <span class="pill" id="left-pill">0 / 0</span>
             </div>
 
         </section>
@@ -72,8 +71,10 @@
       const sessionId = {{ session_id|int }};
       const clockEl = document.querySelector('.clock');
       const subEl = document.querySelector('.sub');
-      const counterEl = document.querySelector('.counter .pill');
+
       const dateEl = document.querySelector('.date');
+      const presentPill = document.getElementById('present-pill');
+      const leftPill    = document.getElementById('left-pill');
 
       async function tick(){
         try{
@@ -82,7 +83,8 @@
           const data = await r.json();
           if(clockEl) clockEl.textContent = data.ora_curenta || '--:--';
           if(subEl) subEl.textContent = `Fereastră check‑in: ${data.window_label}. Bife verzi = prezenți.`;
-          if(counterEl) counterEl.textContent = `${data.present_count} / ${data.total}`;
+          if (presentPill) presentPill.textContent = `${data.present_count} / ${data.total}`;
+          if (leftPill)    leftPill.textContent    = `${data.left_count} / ${data.present_count}`;
           if (dateEl) dateEl.textContent = data.data_curenta || '';
         }catch(e){ /* ignorăm erorile intermitente */ }
         setTimeout(tick, 3000);
@@ -92,68 +94,68 @@
 </script>
 
 <script>
-(function(){
-  const params    = new URLSearchParams(location.search);
-  const sessionId = Number(params.get('session_id'));
-  if (!sessionId) { console.warn('Lipsește ?session_id='); return; }
+    (function(){
+      const params    = new URLSearchParams(location.search);
+      const sessionId = Number(params.get('session_id'));
+      if (!sessionId) { console.warn('Lipsește ?session_id='); return; }
 
-  const clockEl   = document.querySelector('.clock');
-  const dateEl    = document.querySelector('.date');
-  const counterEl = document.querySelector('.counter .pill');
-  const qrImg     = document.getElementById('qr-img');
-  const qrTitleEl = document.getElementById('qr-title');
-  const qrDebugEl = document.getElementById('qr-debug');
-  const qrScanTextEl = document.getElementById('qr-scan-text');
+      const clockEl   = document.querySelector('.clock');
+      const dateEl    = document.querySelector('.date');
+      const counterEl = document.querySelector('.counter .pill');
+      const qrImg     = document.getElementById('qr-img');
+      const qrTitleEl = document.getElementById('qr-title');
+      const qrDebugEl = document.getElementById('qr-debug');
+      const qrScanTextEl = document.getElementById('qr-scan-text');
 
-  let lastToken = null;
+      let lastToken = null;
 
-  async function tick(){
-    try{
-      const r = await fetch(`/api/monitor_status?session_id=${sessionId}`, {cache:'no-store'});
-      if(!r.ok){ console.log('API status', r.status); setTimeout(tick, 3000); return; }
-      const data = await r.json();
-      console.log('API:', {mode: data.mode, hasToken: !!data.qr_token});
+      async function tick(){
+        try{
+          const r = await fetch(`/api/monitor_status?session_id=${sessionId}`, {cache:'no-store'});
+          if(!r.ok){ console.log('API status', r.status); setTimeout(tick, 3000); return; }
+          const data = await r.json();
+          console.log('API:', {mode: data.mode, hasToken: !!data.qr_token});
 
-      if (clockEl)   clockEl.textContent = data.ora_curenta || '--:--';
-      if (dateEl)    dateEl.textContent  = data.data_curenta || '';
-      if (counterEl) counterEl.textContent = `${data.present_count} / ${data.total}`;
+          if (clockEl)   clockEl.textContent = data.ora_curenta || '--:--';
+          if (dateEl)    dateEl.textContent  = data.data_curenta || '';
+          if (counterEl) counterEl.textContent = `${data.present_count} / ${data.total}`;
 
-      if (qrTitleEl){
-        qrTitleEl.textContent =
-          data.mode === 'end'    ? 'Cod de final de oră' :
-          data.mode === 'active' ? 'Cod de început de oră' :
-          'Ora este în desfășurare';
-      }
+          if (qrTitleEl){
+            qrTitleEl.textContent =
+              data.mode === 'end'    ? 'Cod de final de oră' :
+              data.mode === 'active' ? 'Cod de început de oră' :
+              'Ora este în desfășurare';
+          }
 
-       if (qrScanTextEl){
-        qrScanTextEl.textContent =
-          data.mode === 'end'    ? 'Scanează pentru a-ți confirma plecarea' :
-          data.mode === 'active' ? 'Scanează pentru a-ți confirma prezența' :
-          '-';
-      }
+           if (qrScanTextEl){
+            qrScanTextEl.textContent =
+              data.mode === 'end'    ? 'Scanează pentru a-ți confirma plecarea' :
+              data.mode === 'active' ? 'Scanează pentru a-ți confirma prezența' :
+              '-';
+          }
 
-      // setează/ascunde QR
-      if (data.qr_token){
-        const v = encodeURIComponent(data.ora_curenta || Date.now());
-        const src = `/qr.png?token=${data.qr_token}&v=${v}`;
-        if (qrImg){
-          qrImg.src = src;
-          qrImg.style.visibility = 'visible';
+          // setează/ascunde QR
+          if (data.qr_token){
+            const v = encodeURIComponent(data.ora_curenta || Date.now());
+            const src = `/qr.png?token=${data.qr_token}&v=${v}`;
+            if (qrImg){
+              qrImg.src = src;
+              qrImg.style.visibility = 'visible';
+            }
+            if (qrDebugEl) qrDebugEl.textContent = `${location.origin}/elev?token=${data.qr_token}`;
+            lastToken = data.qr_token;
+            console.log('SET QR IMG:', src);
+          } else {
+            if (qrImg) qrImg.style.visibility = 'hidden';
+            if (qrDebugEl) qrDebugEl.textContent = '';
+          }
+        } catch(e){
+          console.error('tick error', e);
         }
-        if (qrDebugEl) qrDebugEl.textContent = `${location.origin}/elev?token=${data.qr_token}`;
-        lastToken = data.qr_token;
-        console.log('SET QR IMG:', src);
-      } else {
-        if (qrImg) qrImg.style.visibility = 'hidden';
-        if (qrDebugEl) qrDebugEl.textContent = '';
+        setTimeout(tick, 3000);
       }
-    } catch(e){
-      console.error('tick error', e);
-    }
-    setTimeout(tick, 3000);
-  }
-  tick();
-})();
+      tick();
+    })();
 </script>
 
 


### PR DESCRIPTION
## Ce aduce
- ✅ Checkout la final de oră (phase=end), cu fereastră [-5m, +5m]
- ✅ QR dinamic: comută automat start→end; expune token prin /api/monitor_status
- ✅ Contor “Prezenți” înghețat după +10m (snapshot salvat în `session`)
- ✅ “Plecați: X / prezenți” (X = left_count, prezenți = snapshot)
- ✅ UI: badge “plecat”, text QR diferit la final (“confirmă plecarea”)

## DB / migrare
- `attendance.check_out_at` (TEXT)
- CHECK extins: `status ∈ {neconfirmat, prezent, întârziat, plecat}`
- `session.present_frozen` (INTEGER), `session.present_frozen_at` (TEXT)
Rulat prin: `flask --app app:create_app init-db`

## Cum testez
1) `flask import-codes docs/authorized_codes_11C.csv`
2) `flask seed-now --class 11C --minutes-ago 42 --duration 50`
3) `GET /monitor?session_id=<id>` → vezi QR “final” în ultimele 5m
4) `GET /elev?token=...` → introdu codul → “Check-out înregistrat”
5) Monitor: “Prezenți” rămâne înghețat; “Plecați: X / prezenți” crește

## Note
- POST-ul la /elev păstrează `token` și `session_id` (hidden inputs)
- API: `/api/monitor_status` returnează `mode`, `phase`, `qr_token`, `present_count`, `left_count`
